### PR TITLE
Fix incorrect static path in theme backgrounds

### DIFF
--- a/frameworks/django/static/css/theme.css
+++ b/frameworks/django/static/css/theme.css
@@ -35,7 +35,7 @@
     --txtbox-border-color-focused: rgb(240, 240, 240);
 }
 :root[data-theme="dark"]{
-    --bg-image: url("static/img/wallpapers/nature_china.jpg");  
+    --bg-image: url("/static/img/wallpapers/nature_china.jpg");  
     
     --bg-color: rgb(45, 45, 45);
     --bg-secondary-color: rgb(75, 75, 75,0.3);
@@ -67,7 +67,7 @@
     --txtbox-border-color-focused: rgb(80, 80, 80);
 }
 :root[data-theme="steam-old"]{
-    --bg-image: url("static/img/wallpapers/nature_china.jpg");  
+    --bg-image: url("/static/img/wallpapers/nature_china.jpg");  
 
     --bg-color: rgb(75, 74, 65);
     --bg-secondary-color: rgb(75, 75, 75,0.3);
@@ -99,7 +99,7 @@
     --txtbox-border-color-focused: rgb(80, 80, 80);
 }
 :root[data-theme="frutiger-aero"]{
-    --bg-image: url("static/img/wallpapers/nature_china.jpg");  
+    --bg-image: url("/static/img/wallpapers/nature_china.jpg");  
 
     --bg-color: rgb(88, 128, 141);
     --bg-secondary-color: rgb(75, 75, 75,0.3);


### PR DESCRIPTION
The themes were already defined in theme.css, but some background images were not loading correctly due to incorrect paths.

Some themes used:
url("static/...")

Instead of:
url("/static/...")

This fix updates the paths to ensure images load properly across all themes.